### PR TITLE
Fix Conversion(WrongType(Int8)) for stream_ordering column

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct RoomRow {
     internal_metadata: serde_json::Value,
     ts: i64,
     edges: Vec<String>,
-    stream_ordering: i32,
+    stream_ordering: i64,
     rejection_reason: Option<String>,
 }
 


### PR DESCRIPTION
No idea if this changed in Synapse recently?